### PR TITLE
Remove Gitment

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -110,15 +110,6 @@ changyan_appkey: false  ##appkey
 ### 填写友言用户ID http://www.uyan.cc/sites
 youyan_uid: false
 
-# gitment
-## 教程：https://imsun.net/posts/gitment-introduction/ 网站上进行查看
-gitment:
-  enable: false #如果不使用则设置false关闭
-  owner: giscafer # 你的github名称或者id id的获取方式为https://api.github.com/users/forvoid（你的名称）中的id极为github id
-  repo: giscafer.github.io # 你的留言存放的位置 我的是放在我的github的github page上面
-  client_id: 7e5dd6cdb9xxaxa4cf91a # Register a new OAuth application https://github.com/settings/applications/new 
-  client_secret: 97f37d5c27c4a511xx4fxx623d391c85cb97f8 
-
 ## disqus
 disqus_shortname: false
 


### PR DESCRIPTION
Gitment 如果不自己搭服务器，无法启用评论功能。因此移除。
相关信息可以查看链接：
https://sherry0429.github.io/2019/02/12/gitment%E4%BF%AE%E5%A4%8D/
